### PR TITLE
Notify of "join" and "leave"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
 doc/
+
+log.txt
+*.log
+*.pid

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ When status is `inactive`, `waiting` will contains the list of username that did
  * This is only allowed for inactive games, when called by a "waiting" user.
     * Will reply with status 403 otherwise.
  * `status` will change to `active` when there is no more waiting players.
+ * a notification will be sent to active players (that aren't in the waiting list)
+    * from coordinator/v1
+    * type join
+    * data.gameId = "123466765785232"
+    * data.player = "username"
 
 # Single Game Leave [/coordinator/v1/auth/:token/games/:id/leave]
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,7 @@ When status is `inactive`, `waiting` will contains the list of username that did
  * This is only allowed for inactive games, when called by a "waiting" user.
     * Will reply with status 403 otherwise.
  * `status` will change to `active` when there is no more waiting players.
- * a notification will be sent to active players (that aren't in the waiting list)
-    * from coordinator/v1
-    * type join
-    * data.gameId = "123466765785232"
-    * data.player = "username"
+ * [a notification](https://github.com/j3k0/ganomede-notifications/blob/master/api-docs/coordinator.md) will be sent to other active players (that aren't in the waiting list)
 
 # Single Game Leave [/coordinator/v1/auth/:token/games/:id/leave]
 
@@ -114,12 +110,7 @@ When status is `inactive`, `waiting` will contains the list of username that did
  * This is only allowed when called by a non waiting user.
     * Will reply with status 403 otherwise.
  * `status` will change to `inactive`
- * a notification will be sent to other players
-    * from coordinator/v1
-    * type leave
-    * data.gameId = "123466765785232"
-    * data.player = "username"
-    * data.reason = "resign"
+ * [a notification](https://github.com/j3k0/ganomede-notifications/blob/master/api-docs/coordinator.md) will be sent to other active players.
 
 # Single Game Over [/coordinator/v1/auth/:token/games/:id/gameover]
 
@@ -223,4 +214,3 @@ Inactive games will have an expiry date of 1 month.
  * `seq`: The update sequence number.
  * `id`: The document ID.
  * `changes`: An array of fields, which by default includes the document’s revision ID, but can also include information about document conflicts and other things.
-

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Configuration
  * `COUCH_GAMES_PORT_5984_TCP_PORT` - Port of the games couchdb
  * `REDIS_AUTH_PORT_6379_TCP_ADDR` - IP of the AuthDB redis
  * `REDIS_AUTH_PORT_6379_TCP_PORT` - Port of the AuthDB redis
+ * `NOTIFICATIONS_PORT_8080_TCP_ADDR` - IP of the notifications service
+ * `NOTIFICATIONS_PORT_8080_TCP_PORT` - Port of the notifications service
  * `GAME_SERVERS_URL` - Comma separated list of servers
  * `API_SECRET` - Give access to private APIs
 
@@ -81,6 +83,14 @@ When status is `inactive`, `waiting` will contains the list of username that did
 
 ## Edit a game [POST]
 
+### body (application/json)
+
+(optional)
+
+    {
+        "reason": "resign"
+    }
+
 ### response [200] OK
 
     {
@@ -99,6 +109,12 @@ When status is `inactive`, `waiting` will contains the list of username that did
  * This is only allowed when called by a non waiting user.
     * Will reply with status 403 otherwise.
  * `status` will change to `inactive`
+ * a notification will be sent to other players
+    * from coordinator/v1
+    * type leave
+    * data.gameId = "123466765785232"
+    * data.player = "username"
+    * data.reason = "resign"
 
 # Single Game Over [/coordinator/v1/auth/:token/games/:id/gameover]
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ else {
     // worker
     var restify = require("restify");
     var main = require("./src/main");
-    var server = require('./src/server');
+    var server = require('./src/server').createServer();
 
     // Intitialize backend, add routes
     main.initialize();

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "newrelic": "^1.20.2",
     "eslint": "^0.10.0",
     "forever": "^0.13.0",
+    "ganomede-helpers": "^0.4.2",
     "jshint": "^2.5.10",
+    "lodash": "^3.10.1",
     "mocha": "^2.0.1",
     "nano": "^6.1.2",
     "restify": "^2.8.3",
@@ -42,6 +44,7 @@
     "istanbul": "https://github.com/duereg/istanbul/archive/master.tar.gz",
     "memdown": "^1.0.0",
     "pouchdb-server": "^0.6.5",
+    "sinon": "^1.16.1",
     "supertest": "^0.15.0"
   }
 }

--- a/src/coordinator-api.coffee
+++ b/src/coordinator-api.coffee
@@ -168,7 +168,8 @@ class CoordinatorApi
 
       req.params.notifications = notifications.leave(game, username)
       if req.body?.reason
-        req.params.notifications.data.reason = req.body.reason
+        req.params.notifications.forEach (n) ->
+          n.data.reason = req.body.reason
       next()
 
     # POST /games/:id/gameover

--- a/src/coordinator-api.coffee
+++ b/src/coordinator-api.coffee
@@ -170,6 +170,11 @@ class CoordinatorApi
       if req.body?.reason
         req.params.notifications.forEach (n) ->
           n.data.reason = req.body.reason
+          if n.data.reason == "resign"
+            n.data.push =
+              app: game.type
+              title: [ "opponent_has_left_title" ]
+              message: [ "opponent_has_left_message", username ]
       next()
 
     # POST /games/:id/gameover

--- a/src/coordinator-api.coffee
+++ b/src/coordinator-api.coffee
@@ -1,8 +1,10 @@
 log = require "./log"
 authdb = require "authdb"
 restify = require "restify"
+helpers = require 'ganomede-helpers'
 config = require '../config'
 gameServers = require './game-servers'
+notifications = require './coordinator-notifications'
 
 sendError = (err, next) ->
   log.error err
@@ -20,6 +22,10 @@ class CoordinatorApi
     @games = options.games
 
     @gameServers = options.gameServers || gameServers
+
+    # function for sending out notifications
+    @sendNotification = options.sendNotification ||
+      helpers.Notification.sendFn()
 
   addRoutes: (prefix, server) ->
 
@@ -110,12 +116,16 @@ class CoordinatorApi
 
     saveGame = (req, res, next) =>
       game = req.params.game
-      game.save (err) ->
+      game.save (err) =>
         if err
           return sendError(err, next)
+
+        # send out notifications if there are any
+        if req.params.notifications?.length
+          notifications.send(@sendNotification, req.params.notifications)
+
         res.send game.toJSON()
         next()
-        # TODO: Send notification
 
     # POST /games/:id/join
     postJoin = (req, res, next) =>
@@ -132,6 +142,8 @@ class CoordinatorApi
       if game.waiting.length == 0
         delete game.waiting
         game.status = "active"
+
+      req.params.notifications = notifications.join(game, username)
       next()
 
     # POST /games/:id/leave
@@ -153,6 +165,8 @@ class CoordinatorApi
       else
         err = new restify.InternalError('Invalid game state')
         return sendError err, next
+
+      req.params.notifications = notifications.leave(game, username)
       next()
 
     # POST /games/:id/gameover

--- a/src/coordinator-api.coffee
+++ b/src/coordinator-api.coffee
@@ -167,6 +167,8 @@ class CoordinatorApi
         return sendError err, next
 
       req.params.notifications = notifications.leave(game, username)
+      if req.body?.reason
+        req.params.notifications.data.reason = req.body.reason
       next()
 
     # POST /games/:id/gameover

--- a/src/coordinator-notifications.coffee
+++ b/src/coordinator-notifications.coffee
@@ -7,11 +7,19 @@ log = require './log'
 JOIN = 'join'
 LEAVE = 'leave'
 
+activePlayers = (game) ->
+  unless game.waiting?.length
+    return game.players
+
+  return game.players.filter (username) ->
+    game.waiting.indexOf(username) == -1
+
 # Returns [helpers.Notification] for every player that should be notified
 # about @playerInQuestion leaving/joining (@type) game @game.
 createNotifications = (type, game, playerInQuestion) ->
   # Notify everyone except @playerInQuestion
-  whoToNotify = game.players.filter (username) -> username != playerInQuestion
+  whoToNotify = activePlayers(game).filter (username) ->
+    username != playerInQuestion
 
   return whoToNotify.map (username) ->
     n = new helpers.Notification({

--- a/src/coordinator-notifications.coffee
+++ b/src/coordinator-notifications.coffee
@@ -32,9 +32,6 @@ createNotifications = (type, game, playerInQuestion) ->
       }
     })
 
-    if type == LEAVE
-      n.data.reason = 'resign'
-
     return n
 
 send = (sendFn, notifications, callback) ->

--- a/src/coordinator-notifications.coffee
+++ b/src/coordinator-notifications.coffee
@@ -1,0 +1,58 @@
+vasync = require 'vasync'
+lodash = require 'lodash'
+helpers = require 'ganomede-helpers'
+config = require '../config'
+log = require './log'
+
+JOIN = 'join'
+LEAVE = 'leave'
+
+# Returns [helpers.Notification] for every player that should be notified
+# about @playerInQuestion leaving/joining (@type) game @game.
+createNotifications = (type, game, playerInQuestion) ->
+  # Notify everyone except @playerInQuestion
+  whoToNotify = game.players.filter (username) -> username != playerInQuestion
+
+  return whoToNotify.map (username) ->
+    n = new helpers.Notification({
+      from: config.routePrefix
+      to: username
+      type: type
+      data: {
+        game: lodash.pick(game, ['id', 'type', 'players'])
+        player: playerInQuestion
+      }
+    })
+
+    if type == LEAVE
+      n.data.reason = 'resign'
+
+    return n
+
+send = (sendFn, notifications, callback) ->
+  iterator = (notification, cb) ->
+    sendFn notification, (err, response) ->
+      if (err)
+        log.error 'coordinator-notifications: .send() failed',
+          err: err
+          notification: notification
+          response: response
+
+      # Ignore errors?
+      cb(err, response)
+
+  vasync.forEachParallel
+    func: iterator
+    inputs: notifications
+  , (err, results) ->
+    if callback instanceof Function
+      callback(err, err || lodash.pluck(results.operations, 'result'))
+
+module.exports = {
+  join: createNotifications.bind(null, JOIN)
+  leave: createNotifications.bind(null, LEAVE)
+  send: send
+
+  JOIN: JOIN
+  LEAVE: LEAVE
+}

--- a/src/couchbone.coffee
+++ b/src/couchbone.coffee
@@ -22,6 +22,8 @@ class Model
       @fromCouch obj
 
   fromCouch: (obj) ->
+    if !obj
+      return
     Object.keys(obj).forEach (key) ->
       thisKey = key
       if @COUCH_KEYS_MAPPING.hasOwnProperty(key)

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -1,9 +1,12 @@
 restify = require('restify')
 
-server = restify.createServer()
+createServer = ->
+  server = restify.createServer()
 
-server.use restify.queryParser()
-server.use restify.bodyParser()
-server.use restify.gzipResponse()
+  server.use restify.queryParser()
+  server.use restify.bodyParser()
+  server.use restify.gzipResponse()
+  return server
 
-module.exports = server
+module.exports =
+  createServer: createServer

--- a/tests/test-coordinator-api.coffee
+++ b/tests/test-coordinator-api.coffee
@@ -231,9 +231,21 @@ describe "Coordinator API", ->
         done()
 
     it 'notifies other active players of defined reason', (done) ->
+      p2Leave "exit", ->
+        notification = sendNotificationSpy.secondCall.args[0]
+        expect(notification.data.reason).to.be("exit")
+        expect(notification.data.push).to.be(undefined)
+        done()
+
+    it 'push notifies other active players when resign', (done) ->
       p2Leave "resign", ->
         notification = sendNotificationSpy.secondCall.args[0]
         expect(notification.data.reason).to.be("resign")
+        expect(notification.data.push).to.be.ok()
+        expect(notification.data.push).to.eql
+          app: samples.postGameRes.type
+          title: [ "opponent_has_left_title" ]
+          message: [ "opponent_has_left_message", "p2" ]
         done()
 
   describe "GET /gameover", ->

--- a/tests/test-coordinator-api.coffee
+++ b/tests/test-coordinator-api.coffee
@@ -138,7 +138,6 @@ describe "Coordinator API", ->
         .post endpoint("/auth/p2-token/games/#{id}/leave")
         .expect 200
         .end (err, res) ->
-          console.dir err
           expect(err).to.be(null)
           expect(res.body).to.eql(samples.leaveGameRes)
           done()
@@ -179,7 +178,6 @@ describe "Coordinator API", ->
         .get endpoint("/gameover?#{secret}&#{since}")
         .expect 200
         .end (err, res) ->
-          console.log(JSON.stringify(res.body))
           expect(res.body.last_seq).to.eql(last_seq + 1)
           expect(res.body.results.length).to.eql(1)
           done()

--- a/tests/test-coordinator-notifications.coffee
+++ b/tests/test-coordinator-notifications.coffee
@@ -1,0 +1,56 @@
+expect = require 'expect.js'
+helpers = require 'ganomede-helpers'
+lodash = require 'lodash'
+notifications = require '../src/coordinator-notifications'
+config = require '../config'
+
+describe 'Coordinator Notifications', () ->
+  playerJoining = 'joiner'
+  playerLeaving = 'leaver'
+  game = {
+    id: 'game-id'
+    type: 'game-type/v1'
+    players: [playerJoining, playerLeaving, 'other-guy']
+    waiting: [playerLeaving]
+  }
+
+  testNotification = (n, expectedType, expectedData={}) ->
+    expect(n).to.be.a(helpers.Notification)
+    expect(n.type).to.be(expectedType)
+    expect(n.from).to.be(config.routePrefix)
+    for own key, val of expectedData
+      compareMethod = if typeof val == 'object' then 'eql' else 'be'
+      expect(n.data[key]).to[compareMethod](val)
+
+  describe '.join()', () ->
+    it 'creates correct `join` notifications', () ->
+      for n in notifications.join(game, playerJoining)
+        testNotification(n, notifications.JOIN, {
+          game: lodash.pick(game, 'id', 'type', 'players')
+          player: playerJoining
+        })
+
+    it 'creates `join` notification for every active player
+        except the one joining',
+    () ->
+      n = notifications.join(game, playerJoining)
+      usersToBeNotified = lodash.pluck(n, 'to')
+      usersExpectedToBeNotified = game.players.filter (u) -> u != playerJoining
+      expect(usersToBeNotified).to.eql(usersExpectedToBeNotified)
+
+  describe '.leave()', () ->
+    it 'creates correct `leave` notifications', () ->
+      for n in notifications.leave(game, playerLeaving)
+        testNotification(n, notifications.LEAVE, {
+          game: lodash.pick(game, 'id', 'type', 'players')
+          player: playerLeaving
+          reason: 'resign'
+        })
+
+    it 'creates `leave` notifications for every active player
+        except the one joining',
+    () ->
+      n = notifications.leave(game, playerLeaving)
+      usersToBeNotified = lodash.pluck(n, 'to')
+      usersExpectedToBeNotified = game.players.filter (u) -> u != playerLeaving
+      expect(usersToBeNotified.sort()).to.eql(usersExpectedToBeNotified.sort())

--- a/tests/test-coordinator-notifications.coffee
+++ b/tests/test-coordinator-notifications.coffee
@@ -36,7 +36,6 @@ describe 'Coordinator Notifications', () ->
       testNotification(n, notifications.LEAVE, {
         game: lodash.pick(game, 'id', 'type', 'players')
         player: playerLeaving
-        reason: 'resign'
       })
 
   it 'creates notifications only for active players


### PR DESCRIPTION
Whenever a player joins an inactive game, or leaves a game in progress, other active players should be notified.

To do that, coordinator will communicate with the notification module.

A `reason` can now be specified to the "leave" action (optionally, to stay compatible with older clients).

See README for more details.